### PR TITLE
Introduce itoo-x wrapper

### DIFF
--- a/.idea/libraries/appinventor.xml
+++ b/.idea/libraries/appinventor.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+  <library name="appinventor">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/deps/appinventor" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+    <jarDirectory url="file://$PROJECT_DIR$/deps/appinventor" recursive="false" />
+  </library>
+</component>

--- a/.idea/libraries/module.xml
+++ b/.idea/libraries/module.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+  <library name="module">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/deps/module" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+    <jarDirectory url="file://$PROJECT_DIR$/deps/module" recursive="false" />
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" project-jdk-name="8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/itoo-x.iml" filepath="$PROJECT_DIR$/.idea/itoo-x.iml" />
+      <module fileurl="file://$PROJECT_DIR$/itoox-wrapper/itoox-wrapper.iml" filepath="$PROJECT_DIR$/itoox-wrapper/itoox-wrapper.iml" />
       <module fileurl="file://$PROJECT_DIR$/youngandroid/youngandroid.iml" filepath="$PROJECT_DIR$/youngandroid/youngandroid.iml" />
     </modules>
   </component>

--- a/itoox-wrapper/itoox-wrapper.iml
+++ b/itoox-wrapper/itoox-wrapper.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="dev-deps" level="project" />
+  </component>
+</module>

--- a/itoox-wrapper/src/xyz/kumaraswamy/itoox/wrapper/FrameworkWrapper.java
+++ b/itoox-wrapper/src/xyz/kumaraswamy/itoox/wrapper/FrameworkWrapper.java
@@ -1,0 +1,113 @@
+package xyz.kumaraswamy.itoox.wrapper;
+
+import android.content.Context;
+import com.google.appinventor.components.runtime.Form;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class FrameworkWrapper {
+
+  private static final String FRAMEWORK_CLASS = "xyz.kumaraswamy.itoox.Framework";
+
+  public static boolean isItooXPresent() {
+    try {
+      Class.forName(FRAMEWORK_CLASS);
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  public static void activateItooX() throws ReflectiveOperationException {
+    if (!isItooXPresent()) {
+      return;
+    }
+    Form form = Form.getActiveForm();
+    if (form == null) {
+      return;
+    }
+    String refScreen = form.getClass().getSimpleName();
+
+    Class<?> itooInt = Class.forName("xyz.kumaraswamy.itoox.ItooInt");
+    Method method = itooInt.getMethod("saveIntStuff", Form.class, String.class);
+
+    // static invoke saveIntStuff(Form, String)
+    method.invoke(null, form, refScreen);
+  }
+
+  private boolean success;
+
+  private Object framework;
+  private Method callProcedureMethod;
+
+  public FrameworkWrapper(Context context, String screen) {
+    if (!isItooXPresent()) {
+      success = false;
+      return;
+    }
+    try {
+      success = safeInit(context, screen);
+    } catch (ReflectiveOperationException e) {
+      e.printStackTrace();
+      success = false;
+    }
+  }
+
+  private boolean safeInit(Context context, String screen) throws ReflectiveOperationException {
+    final boolean success;
+    Class<?> clazz = Class.forName(FRAMEWORK_CLASS);
+    Object result = clazz.getMethod("get", Context.class, String.class)
+        // static method invocation
+        // get(Context, String)
+        .invoke(null, context, screen);
+    Class<?> resultClazz = result.getClass();
+    // success() method
+    success = (boolean) resultClazz.getMethod("success").invoke(result);
+    if (success) {
+      framework = resultClazz.getMethod("getFramework").invoke(result);
+      callProcedureMethod = clazz.getMethod("call", String.class, Object[].class);
+    }
+    return success;
+  }
+
+  public boolean success() {
+    return success;
+  }
+
+  public Object call(String procedure, Object... args) {
+    try {
+      return safeCall(procedure, args);
+    } catch (ReflectiveOperationException e) {
+      e.printStackTrace();
+      return Result.BAD;
+    }
+  }
+
+  private Object safeCall(String procedure, Object[] args) throws ReflectiveOperationException {
+    Object callResult = callProcedureMethod.invoke(framework, procedure, args);
+    Class<?> callResultClazz = callResult.getClass();
+    // success()
+    boolean success = (boolean) callResultClazz.getMethod("success").invoke(callResult);
+    if (!success) {
+      return Result.BAD;
+    }
+    return callResultClazz.getMethod("get").invoke(callResult);
+  }
+
+  public boolean close() {
+    try {
+      return (boolean) framework.getClass().getMethod("close").invoke(framework);
+    } catch (ReflectiveOperationException e) {
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  public enum Result {
+    // well, we need something unique to return when
+    // procedure invocation fails...
+    BAD,
+    SUCCESS
+  }
+}

--- a/src/xyz/kumaraswamy/itoox/InstanceForm.java
+++ b/src/xyz/kumaraswamy/itoox/InstanceForm.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map;
 import java.util.Set;
 
 import xyz.kumaraswamy.itoox.ItooCreator.EnvironmentX;


### PR DESCRIPTION
Intermediate wrapper functionality.
Why? When we use this class we do not need to include the full `itoo-x` module incases where `itoo-x` is already present. 

This avoids class conflicts, class missing problems.

`Extension -> ItooWrapper -> (Is Itoo X present ?) -> Itoo X`